### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Actions Test
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Connor24601/ssoss/security/code-scanning/2](https://github.com/Connor24601/ssoss/security/code-scanning/2)

To fix the problem, we should add a `permissions` block specifying the minimum privileges needed for the workflow. For the code shown, none of the workflow steps require write access to repository contents, or to issues, pull requests, etc. The only external action used is `actions/checkout@v4`, which only requires read access to `contents`. Thus, setting permissions to `contents: read` is a minimal and safe default.

This block can be added at the root of the workflow file, immediately after the `name:` and before the `on:` key, so that it applies to all jobs (unless overridden for specific jobs). No other code or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
